### PR TITLE
Remove unsupported parameter

### DIFF
--- a/MiniGraph/functions/Invoke-GraphRequestBatch.ps1
+++ b/MiniGraph/functions/Invoke-GraphRequestBatch.ps1
@@ -189,7 +189,7 @@
 				}
 
 				try {
-                (MiniGraph\Invoke-GraphRequestBatch -Name $Name -Request $retry -NoProgress -ErrorAction Stop).responses
+                (MiniGraph\Invoke-GraphRequestBatch -Request $retry -ErrorAction Stop).responses
 				}
 				catch {
 					Write-Error -Message "Error sending retry batch: $($_.Exception.Message)" -TargetObject $retry


### PR DESCRIPTION
Remove unsupported parameter in Invoke-GraphRequestBatch's retry step - sorry about that. I seem to have missed it in the initial commit.